### PR TITLE
LocationManager 싱글톤 추가

### DIFF
--- a/empathy-ios.xcodeproj/project.pbxproj
+++ b/empathy-ios.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		55090CBA21B2DEE600147D20 /* TrackingDotHalo@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 55090CAD21B2DEE600147D20 /* TrackingDotHalo@2x.png */; };
 		55090CBB21B2DEE600147D20 /* icon_clustering@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 55090CAE21B2DEE600147D20 /* icon_clustering@2x.png */; };
 		55090CBC21B2DEE600147D20 /* TrackingDot.png in Resources */ = {isa = PBXBuildFile; fileRef = 55090CAF21B2DEE600147D20 /* TrackingDot.png */; };
+		55090CBE21B2F0EF00147D20 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55090CBD21B2F0EF00147D20 /* LocationManager.swift */; };
 		55A3317421900944005DFA01 /* CapturedImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A3317321900944005DFA01 /* CapturedImageViewController.swift */; };
 		55A331772191A84D005DFA01 /* FilterCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A331762191A84D005DFA01 /* FilterCollectionView.swift */; };
 		55A331792192A0A0005DFA01 /* FilterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A331782192A0A0005DFA01 /* FilterController.swift */; };
@@ -167,6 +168,7 @@
 		55090CAD21B2DEE600147D20 /* TrackingDotHalo@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "TrackingDotHalo@2x.png"; sourceTree = "<group>"; };
 		55090CAE21B2DEE600147D20 /* icon_clustering@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon_clustering@2x.png"; sourceTree = "<group>"; };
 		55090CAF21B2DEE600147D20 /* TrackingDot.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TrackingDot.png; sourceTree = "<group>"; };
+		55090CBD21B2F0EF00147D20 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		55A3317321900944005DFA01 /* CapturedImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedImageViewController.swift; sourceTree = "<group>"; };
 		55A331762191A84D005DFA01 /* FilterCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCollectionView.swift; sourceTree = "<group>"; };
 		55A331782192A0A0005DFA01 /* FilterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterController.swift; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 				5577097E21AA144800363CE3 /* Camera */,
 				03F88CF921A520C900084E8E /* Feed */,
 				03F2F1092194AECE00A98241 /* Login */,
+				55090CBD21B2F0EF00147D20 /* LocationManager.swift */,
 				55BC062121809A7400FE43CA /* Assets.xcassets */,
 				55BC062321809A7400FE43CA /* LaunchScreen.storyboard */,
 				55BC062621809A7400FE43CA /* Info.plist */,
@@ -837,6 +840,7 @@
 				55BC061D21809A7300FE43CA /* CameraViewController.swift in Sources */,
 				03F2F10F21952DEA00A98241 /* RoundedButton.swift in Sources */,
 				035A8A5C21AC662F00CA3B8C /* AffiliateDetailViewController.swift in Sources */,
+				55090CBE21B2F0EF00147D20 /* LocationManager.swift in Sources */,
 				55BC061B21809A7300FE43CA /* AppDelegate.swift in Sources */,
 				55DFA365219C4675001B23AC /* ssd_mobilenet_feature_extractor.mlmodel in Sources */,
 				C280DC9521AF1D5700A54D82 /* FetchDetailFeed.swift in Sources */,

--- a/empathy-ios/LocationManager.swift
+++ b/empathy-ios/LocationManager.swift
@@ -1,0 +1,110 @@
+//
+//  File.swift
+//  empathy-ios
+//
+//  Created by GwakDoyoung on 02/12/2018.
+//  Copyright © 2018 tucan9389. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+class LocationManager: NSObject {
+    
+    static let shared = LocationManager()
+    
+    fileprivate let locationManager = CLLocationManager()
+    fileprivate var locValue: CLLocationCoordinate2D?
+    
+    override init() {
+        super.init()
+    }
+    
+    typealias LocationCallback = ((CLLocationCoordinate2D?) -> ())
+    fileprivate var complete: LocationCallback? = nil
+    
+    func requestLocation(complete: @escaping LocationCallback) {
+        if let locValue = self.locValue {
+            complete(locValue)
+        } else {
+            self.complete = complete
+            // Ask for Authorisation from the User.
+            self.locationManager.requestAlwaysAuthorization()
+            
+            // For use in foreground
+            self.locationManager.requestWhenInUseAuthorization()
+            
+            if CLLocationManager.locationServicesEnabled() {
+                locationManager.delegate = self
+                locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+                locationManager.startUpdatingLocation()
+            }
+        }
+    }
+    
+    fileprivate let dict = [
+        "Seoul": [37.56667, 126.97806],
+        "Incheon": [37.45639, 126.70528],
+        "Daejeon": [37.56667, 126.97806],
+        "Daegue": [36.35111, 127.38500],
+        "Gwangju": [35.15972, 126.85306],
+        "Busan": [35.17944, 129.07556],
+        "Ulsan": [35.53889, 129.31667],
+        "Sejong": [36.48750, 127.28167],
+        "GyeonggiDo": [37.56667, 126.97806],
+        "GangwonDo": [37.8633724,127.1265699],
+        "ChungcheongbukDo": [36.6371934,127.4064467],
+        "ChungcheongnamDo": [36.537139,126.2333762],
+        "GyeongsangbukDo": [36.5566144,128.7244566],
+        "GyeongsangnamDo": [35.1813852,127.8305914],
+        "Jeollabukdo": [37.56667, 126.97806],
+        "JeollanamDo": [37.56667, 126.97806],
+        "Jejudo": [33.50000, 126.51667],
+    ]
+    
+    func getNearestLocationEnum(location: CLLocationCoordinate2D) -> LocationEnum {
+        var minLocal = ""
+        var min = 100000000.0
+        for local in dict.keys {
+            if let position = dict[local] {
+                let dist = pow((position[0] - location.latitude), 2) + pow((position[1] - location.longitude), 2)
+                if min > dist {
+                    min = dist
+                    minLocal = local
+                }
+            }
+        }
+        
+        if minLocal == "Seoul" || minLocal == "GyeonggiDo" {
+            if let position = dict[minLocal] {
+                var dist = pow((position[0] - location.latitude), 2) + pow((position[1] - location.longitude), 2)
+                dist = sqrt(dist)
+                if dist < 127.1755433 - 126.8494651 {
+                    return .Seoul
+                } else {
+                    return .GyeonggiDo
+                }
+            }
+        } else {
+            return LocationEnum(rawValue: minLocal) ?? .none
+        }
+        
+        return .none
+    }
+}
+
+extension LocationManager: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let locValue: CLLocationCoordinate2D = manager.location?.coordinate else { return }
+        print("locations = \(locValue.latitude) \(locValue.longitude)")
+        locationManager.stopUpdatingLocation()
+        locationManager.delegate = nil
+        
+        if self.locValue == nil {
+            self.locValue = locValue
+            if let complete = self.complete {
+                complete(self.locValue)
+            }
+        }
+    }
+}

--- a/empathy-ios/Model/LocationEnum.swift
+++ b/empathy-ios/Model/LocationEnum.swift
@@ -26,4 +26,5 @@ enum LocationEnum:String {
     case Jeollabukdo = "Jeollabukdo"
     case JeollanamDo = "JeollanamDo"
     case Jejudo = "Jejudo"
+    case none
 }


### PR DESCRIPTION
`LocationManager`는 두가지 함수를 제공합니다.
- `requestLocation`
- `getNearestLocationEnum`

`getNearestLocationEnum`를 호출하기 위해서는 `CLLocationCoordinate2D`(위도경도자료)가 필요합니다. 위도경도자료는 `requestLocation`를 호출하여 콜백으로 얻어낼 수 있습니다.

아래 코드를 참고해주세요.

```swift
LocationManager.shared.requestLocation { (locationCoordinate2D) in
    print(locationCoordinate2D?.longitude, locationCoordinate2D?.longitude)
    
    if let locationCoordinate2D = locationCoordinate2D {
        let locationEnum: LocationEnum = LocationManager.shared.getNearestLocationEnum(location: locationCoordinate2D)
        
        print(locationEnum)
    }
}
```
